### PR TITLE
increase php memory limit (to enable processing of very large uploads)

### DIFF
--- a/fossology-on-steroids/Dockerfile
+++ b/fossology-on-steroids/Dockerfile
@@ -12,7 +12,7 @@ RUN a2enmod ssl \
     -i.bak \
     -e "s/upload_max_filesize = 700M/upload_max_filesize = 1000M/" \
     -e "s/post_max_size = 701M/post_max_size = 1004M/" \
-    -e "s/memory_limit = 702M/memory_limit = 1010M/" \
+    -e "s/memory_limit = 702M/memory_limit = 3030M/" \
     $phpIni \
   && cp $phpIni /fossology/php.ini
 


### PR DESCRIPTION
eg. e2fsprogs package requires ~3GB of memory to successfully process all API calls